### PR TITLE
Add support for doc'd search_paths in reboot role

### DIFF
--- a/roles/reboot/tasks/main.yml
+++ b/roles/reboot/tasks/main.yml
@@ -5,6 +5,7 @@
     post_reboot_delay: "{{ reboot_post_delay }}"
     pre_reboot_delay: "{{ reboot_pre_delay }}"
     reboot_timeout: "{{ reboot_timeout }}"
+    search_paths: "{{ reboot_search_paths | default(omit) }}"
     test_command: "{{ reboot_test_command | default(omit) }}"
   become: "{{ reboot_become }}"
   become_user: "{{ reboot_become_user }}"


### PR DESCRIPTION
This task param is listed in the reboot role docs[0], but not handled in the task itself.

[0]: https://github.com/oasis-roles/ansible_collection_system/blob/master/roles/reboot/README.md