### PR TITLE
Set the Ubuntu scenario for libvirtd

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           set -ex
           sudo apt-get update
-          sudo apt-get install -y libapt-pkg-dev build-essential python3-setuptools
+          sudo apt-get install -y libapt-pkg-dev build-essential python3-setuptools python3-apt
           python -m pip install --upgrade pip
           pip install -U setuptools wheel
           pip install tox tox-ansible

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: oasis_roles
 name: system
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.1.1
+version: 1.1.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/libvirtd/molecule/ubuntu/playbook.yml
+++ b/roles/libvirtd/molecule/ubuntu/playbook.yml
@@ -2,3 +2,5 @@
   hosts: localhost
   roles:
     - role: libvirtd
+  vars:
+    ansible_python_interpreter: /usr/bin/python3

--- a/roles/libvirtd/molecule/ubuntu/requirements.txt
+++ b/roles/libvirtd/molecule/ubuntu/requirements.txt
@@ -1,1 +1,0 @@
-git+https://git.launchpad.net/python-apt@1.8.y


### PR DESCRIPTION
Fixes the libvirtd-ubuntu build

Installs python3-apt directly to the host
Sets interpreter for running on host to /usr/bin/python3
Removes requirements.txt, as the dep is now directly installed to the host interpreter
Bumps galaxy.yml to prepare 1.1.2 release