### PR TITLE
[CSS-3240] Add retry for RHSM register

### DIFF
--- a/roles/rhsm/defaults/main.yml
+++ b/roles/rhsm/defaults/main.yml
@@ -85,3 +85,9 @@ rhsm_release: null
 # all other repositories will be disabled. The "only" state is mutally
 # exclusive to the enabled/disabled states.
 rhsm_repositories: {}
+
+# The amount of times to retry the task if it fails.
+rhsm_register_retries: 5
+
+# The amount of time between retries of the failing register task.
+rhsm_register_delay: 10

--- a/roles/rhsm/tasks/subscribe.yml
+++ b/roles/rhsm/tasks/subscribe.yml
@@ -21,3 +21,7 @@
     consumer_id: "{{ rhsm_consumer_id }}"
     force_register: "{{ rhsm_force_register }}"
     syspurpose: "{{ rhsm_syspurpose }}"
+  register: subscribed
+  retries: "{{ rhsm_register_retries }}"
+  delay: "{{ rhsm_register_delay }}"
+  until: subscribed is success


### PR DESCRIPTION
This will retry until subscribed is success and will retry 5 time
by default with 10 second delays.