### PR TITLE
added support for multiple NTP client subnets

### DIFF
--- a/roles/chrony/README.md
+++ b/roles/chrony/README.md
@@ -27,7 +27,8 @@ Currently the following variables are supported:
 * `chrony_enable_rtcsync` - Enable/disable kernel synchronization of the real-time clock (RTC) (set to `true` by default)
 * `chrony_hwtimestamp_interfaces` - A list of interfaces in which to enable hardware timestamping. Entered as a string separating each interface with a space (not configured by default)
 * `chrony_num_minsources` - The minimum number of select-able sources required to adjust the system clock (not configured by default)
-* `chrony_ntp_client` - The local network from which to allow NTP client access (not configured by default)
+* `chrony_ntp_client` - [DEPRECATING] The local network from which to allow NTP client access (not configured by default)
+* `chrony_ntp_clients` - A list of networks from which to allow NTP client access (not configured by default)
 * `chrony_keyfile_path` - Path to a key file on the remote hosts for NTP authentication (not configured by default)
 * `chrony_logdir_path` - Path to a directory on the remote hosts in which to store log files (set to `/var/log/chrony` by default)
 * `chrony_logged_information` - A list of information to log. Entered as a string separating each piece of information with a space (not configured by default)
@@ -54,4 +55,4 @@ GPLv3
 Author Information
 ------------------
 
-Andrew Euredjian <aeuredji@redhat.com>
+Andrew Euredjian

--- a/roles/chrony/defaults/main.yml
+++ b/roles/chrony/defaults/main.yml
@@ -34,6 +34,12 @@ chrony_enable_rtcsync: true
 # Set the local network from which to allow NTP client access
 # chrony_ntp_client: 192.168.0.0/16
 
+# The networks from which to allow NTP client access
+# chrony_ntp_clients:
+#   - 10.0.0.0/8
+#   - 172.16.0.0/12
+#   - 192.168.0.0/16
+
 # Specify path to the file containing keys for NTP authentication
 # chrony_keyfile_path: /etc/chrony.keys
 

--- a/roles/chrony/templates/chrony.conf
+++ b/roles/chrony/templates/chrony.conf
@@ -24,6 +24,10 @@ hwtimestamp {{ chrony_hwtimestamp_interfaces }}
 minsources {{ chrony_num_minsources }}
 {%- endif %}
 
+{% if chrony_ntp_client is defined -%}
+allow {{ chrony_ntp_client }}
+{%- endif %}
+
 {% if chrony_ntp_clients is defined -%}
 {% for client_subnet in chrony_ntp_clients %}
 allow {{ client_subnet }}

--- a/roles/chrony/templates/chrony.conf
+++ b/roles/chrony/templates/chrony.conf
@@ -24,8 +24,10 @@ hwtimestamp {{ chrony_hwtimestamp_interfaces }}
 minsources {{ chrony_num_minsources }}
 {%- endif %}
 
-{% if chrony_ntp_client is defined -%}
-allow {{ chrony_ntp_client }}
+{% if chrony_ntp_clients is defined -%}
+{% for client_subnet in chrony_ntp_clients %}
+allow {{ client_subnet }}
+{% endfor %}
 {%- endif %}
 
 {% if chrony_keyfile_path is defined -%}


### PR DESCRIPTION
last template only supports single NTP client subnet,
I adopted the NTP server configuration section to support multiple subnets,
and have changed the template locally to verify this change.