### PR TITLE
Fix repo changes test

### DIFF
--- a/roles/system_repositories/molecule/container_fedora/molecule.yml
+++ b/roles/system_repositories/molecule/container_fedora/molecule.yml
@@ -6,3 +6,14 @@ platforms:
 provisioner:
   playbooks:
     converge: playbook.yml
+  inventory:
+    host_vars:
+      instance_docker_fedora:
+        system_repositories_configs:
+          - name: fedora-debuginfo-test
+            metalink: https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$$releasever&arch=$$basearch
+            gpgcheck: true
+            enabled: true
+            description: fedora-debuginfo-test
+            gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$$releasever-$$basearch
+        system_repositories_rpm_keys: []

--- a/roles/system_repositories/molecule/container_fedora/playbook.yml
+++ b/roles/system_repositories/molecule/container_fedora/playbook.yml
@@ -2,19 +2,12 @@
   hosts: all
   roles:
     - role: system_repositories
-      system_repositories_configs:
-        - name: google-chrome
-          baseurl: http://dl.google.com/linux/chrome/rpm/stable/x86_64
-          gpgcheck: true
-          enabled: true
-          description: google-chrome
-          gpgkey: https://dl.google.com/linux/linux_signing_key.pub
   post_tasks:
-    - name: install google-chrome
+    - name: install gcc-debuginfo
       become: true
       package:
-        name: google-chrome-stable
+        name: gcc-debuginfo
         state: present
       retries: 2
-      register: install_chrome
-      until: install_chrome is success
+      register: install_gcc
+      until: install_gcc is success

--- a/roles/system_repositories/molecule/container_fedora/tests/test_package_install.py
+++ b/roles/system_repositories/molecule/container_fedora/tests/test_package_install.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.mark.parametrize('name', [
-    ('google-chrome-stable')
+    ('gcc-debuginfo')
 ])
 def test_package(host, name):
     assert host.package(name).is_installed

--- a/roles/system_repositories/tasks/main.yml
+++ b/roles/system_repositories/tasks/main.yml
@@ -27,7 +27,7 @@
     group: "{{ system_repositories_group }}"
     mode: "{{ system_repositories_mode }}"
     reposdir: "{{ system_repositories_destination_folder }}"
-  with_items: "{{ system_repositories_configs }}"
+  loop: "{{ system_repositories_configs }}"
 
 - name: download repo files
   become: "{{ system_repositories_become }}"
@@ -38,7 +38,7 @@
     owner: "{{ system_repositories_owner }}"
     group: "{{ system_repositories_group }}"
     mode: "{{ system_repositories_mode }}"
-  with_items: "{{ system_repositories_repo_files }}"
+  loop: "{{ system_repositories_repo_files }}"
   register: get_repo_file
   until: get_repo_file is success
   retries: 3
@@ -49,7 +49,7 @@
     key: "{{ item }}"
     state: present
     validate_certs: "{{ system_repositories_validate_certs }}"
-  with_items: "{{ system_repositories_rpm_keys }}"
+  loop: "{{ system_repositories_rpm_keys }}"
   register: install_rpm_key
   until: install_rpm_key is success
   retries: 3

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,14 @@
 skipdist = true
 minimum_version = 3.2
 envlist = lint_all
-requires = tox-ansible
+requires = tox-ansible>=1.5
 
 [pytest]
 junit_family = xunit2
 
 [ansible]
 molecule_opts =
-    -c
+molecule_config_files =
     {toxinidir}/tests/molecule.yml
 
 [testenv]


### PR DESCRIPTION
Google Chrome repo now changes its installed values. Move to one that's less likely to do that (because it already exists, but is disabled).