### PR TITLE
Allow update_ca_trust to accept templates

### DIFF
--- a/roles/update_ca_trust/README.md
+++ b/roles/update_ca_trust/README.md
@@ -30,6 +30,12 @@ Currently the following variables are supported:
 * `update_ca_trust_files` -  List of local files on the Ansible control machine
   from which to install certificates
 
+* `update_ca_trust_template` - Default: false. If set to true, then the contents
+  of each certificate are loaded as if they are a Jinja2 template. False, by
+  default, loads the file exactly as it is written. It should be safe to use
+  templating, because most syntaxes - including X509 - do not use Jinja2 strings
+  as part of their format.
+
 * `update_ca_trust_become` - Whether or not to use the `become` feature of
   Ansible to gain admin privileges.  Defaults to `true`.
 

--- a/roles/update_ca_trust/defaults/main.yml
+++ b/roles/update_ca_trust/defaults/main.yml
@@ -17,3 +17,5 @@ update_ca_trust_become: true
 
 # The user to sudo/become
 update_ca_trust_become_user: root
+
+update_ca_trust_template: false

--- a/roles/update_ca_trust/tasks/main.yml
+++ b/roles/update_ca_trust/tasks/main.yml
@@ -24,8 +24,8 @@
 
   - name: install certs from files
     copy:
-      src: "{{ item }}"
-      dest: "{{ update_ca_trust_anchors }}"
+      content: "{{ lookup( update_ca_trust_template | bool | ternary('template', 'file'), item) }}\n"
+      dest: "{{ update_ca_trust_anchors }}/{{ item | basename }}"
       owner: root
       group: root
       mode: 0644


### PR DESCRIPTION
This modifies the update_ca_trust role to not only updload files as-is but to also allow them to optionally be template files.